### PR TITLE
Change when http verification happens

### DIFF
--- a/src/main/java/ClientConnection.java
+++ b/src/main/java/ClientConnection.java
@@ -16,7 +16,7 @@ public class ClientConnection {
     server = new ServerSocket(portNumber);
   }
 
-  public String[] receiveRequest() throws IOException {
+  public String receiveRequest() throws IOException {
     StringBuilder request = new StringBuilder();
     clientSocket = server.accept();
     InputStreamReader isr = new InputStreamReader(clientSocket.getInputStream());
@@ -27,7 +27,7 @@ public class ClientConnection {
       request.append("\n");
       line = reader.readLine();
     }
-    return request.toString().split("\\s+");
+    return request.toString();
   }
 
   public void sendResponse(String response) throws IOException {

--- a/src/main/java/ClientConnection.java
+++ b/src/main/java/ClientConnection.java
@@ -16,7 +16,7 @@ public class ClientConnection {
     server = new ServerSocket(portNumber);
   }
 
-  public String receiveRequest() throws IOException {
+  public String[] receiveRequest() throws IOException {
     StringBuilder request = new StringBuilder();
     clientSocket = server.accept();
     InputStreamReader isr = new InputStreamReader(clientSocket.getInputStream());
@@ -27,7 +27,7 @@ public class ClientConnection {
       request.append("\n");
       line = reader.readLine();
     }
-    return request.toString();
+    return request.toString().split("\\s+");
   }
 
   public void sendResponse(String response) throws IOException {

--- a/src/main/java/HttpServer.java
+++ b/src/main/java/HttpServer.java
@@ -8,7 +8,8 @@ public class HttpServer{
     HttpVerifier verifier = new HttpVerifier();
     RequestHandler handler = new RequestHandler(verifier);
     ClientConnection server = new ClientConnection(8080);
-    HttpServerRunner runner = new HttpServerRunner(server, handler);
+    ParseString parser = new ParseString();
+    HttpServerRunner runner = new HttpServerRunner(server, handler, parser);
     runner.runServer();
   }
 }

--- a/src/main/java/HttpServerRunner.java
+++ b/src/main/java/HttpServerRunner.java
@@ -5,19 +5,23 @@ public class HttpServerRunner {
 
   RequestHandler handler;
   ClientConnection clientConnection;
+  IParser parser;
 
-  public HttpServerRunner(ClientConnection connection, RequestHandler requestHandler) {
+  public HttpServerRunner(ClientConnection connection, RequestHandler requestHandler, IParser parseString) {
     clientConnection = connection;
     handler = requestHandler;
+    parser = parseString;
   }
 
   public void runServer() throws IOException {
-    String[] request;
+    String request;
+    String request_array[];
     String response;
     HttpRequest httpRequest;
     while(true) {
       request = clientConnection.receiveRequest();
-      response = handler.processRequest(request);
+      request_array = parser.parse(request);
+      response = handler.processRequest(request_array);
       clientConnection.sendResponse(response);
     }
   }

--- a/src/main/java/HttpServerRunner.java
+++ b/src/main/java/HttpServerRunner.java
@@ -12,14 +12,12 @@ public class HttpServerRunner {
   }
 
   public void runServer() throws IOException {
-    String request;
+    String[] request;
     String response;
     HttpRequest httpRequest;
     while(true) {
       request = clientConnection.receiveRequest();
-      httpRequest = new HttpRequest(request);
-      System.out.print(request);
-      response = handler.processRequest(httpRequest);
+      response = handler.processRequest(request);
       clientConnection.sendResponse(response);
     }
   }

--- a/src/main/java/HttpVerifier.java
+++ b/src/main/java/HttpVerifier.java
@@ -3,10 +3,14 @@ package com.td.HttpServer;
 public class HttpVerifier implements IValidator {
 
   public boolean isValid(String[] request) {
-
-    return isMethodValid(request[0]) &&
-           isPathValid(request[1]) &&
-           isVersionValid(request[2]);
+    try {
+      return isMethodValid(request[0]) &&
+        isPathValid(request[1]) &&
+        isVersionValid(request[2]);
+    }
+    catch (IndexOutOfBoundsException e) {
+      return false;
+    }
   }
 
   private boolean isMethodValid(String method) {

--- a/src/main/java/HttpVerifier.java
+++ b/src/main/java/HttpVerifier.java
@@ -1,12 +1,12 @@
 package com.td.HttpServer;
 
-public class HttpVerifier implements Validator {
+public class HttpVerifier implements IValidator {
 
-  public boolean isValid(HttpProtocal request) {
+  public boolean isValid(String[] request) {
 
-    return isMethodValid(request.method()) &&
-           isPathValid(request.path()) &&
-           isVersionValid(request.version());
+    return isMethodValid(request[0]) &&
+           isPathValid(request[1]) &&
+           isVersionValid(request[2]);
   }
 
   private boolean isMethodValid(String method) {

--- a/src/main/java/HttpVerifier.java
+++ b/src/main/java/HttpVerifier.java
@@ -1,28 +1,33 @@
 package com.td.HttpServer;
+import java.util.*;
 
 public class HttpVerifier implements IValidator {
 
+  List<String> validMethods;
+
+  public HttpVerifier() {
+    validMethods = new ArrayList<String>();
+    validMethods.add("GET");
+    validMethods.add("HEAD");
+    validMethods.add("POST");
+    validMethods.add("PUT");
+    validMethods.add("DELETE");
+    validMethods.add("TRACE");
+    validMethods.add("OPTIONS");
+    validMethods.add("CONNECT");
+    validMethods.add("PATCH");
+  }
+
   public boolean isValid(String[] request) {
-    try {
-      return isMethodValid(request[0]) &&
-        isPathValid(request[1]) &&
-        isVersionValid(request[2]);
-    }
-    catch (IndexOutOfBoundsException e) {
-      return false;
-    }
+    if ( request.length < 3 ) return false;
+
+    return isMethodValid(request[0]) &&
+      isPathValid(request[1]) &&
+      isVersionValid(request[2]);
   }
 
   private boolean isMethodValid(String method) {
-    return isRequestGet(method) ||
-           isRequestHead(method) ||
-           isRequestPost(method) ||
-           isRequestPut(method) ||
-           isRequestDelete(method) ||
-           isRequestTrace(method) ||
-           isRequestOptions(method) ||
-           isRequestConnect(method) ||
-           isRequestPatch(method);
+    return validMethods.contains(method);
   }
 
   private boolean isPathValid(String path) {
@@ -31,41 +36,5 @@ public class HttpVerifier implements IValidator {
 
   private boolean isVersionValid(String version) {
     return version.equals("HTTP/1.1");
-  }
-
-  private boolean isRequestGet(String method) {
-    return method.equals("GET");
-  }
-
-  private boolean isRequestHead(String method) {
-    return method.equals("HEAD");
-  }
-
-  private boolean isRequestPost(String method) {
-    return method.equals("POST");
-  }
-
-  private boolean isRequestPut(String method) {
-    return method.equals("PUT");
-  }
-
-  private boolean isRequestDelete(String method) {
-    return method.equals("DELETE");
-  }
-
-  private boolean isRequestTrace(String method) {
-    return method.equals("TRACE");
-  }
-
-  private boolean isRequestOptions(String method) {
-    return method.equals("OPTIONS");
-  }
-
-  private boolean isRequestConnect(String method) {
-    return method.equals("CONNECT");
-  }
-
-  private boolean isRequestPatch(String method) {
-    return method.equals("PATCH");
   }
 }

--- a/src/main/java/IParser.java
+++ b/src/main/java/IParser.java
@@ -1,0 +1,5 @@
+package com.td.HttpServer;
+
+public interface IParser {
+  public String[] parse(String toParse);
+}

--- a/src/main/java/IValidator.java
+++ b/src/main/java/IValidator.java
@@ -1,0 +1,7 @@
+package com.td.HttpServer;
+
+public interface IValidator {
+
+  public boolean isValid(String[] request);
+
+}

--- a/src/main/java/ParseString.java
+++ b/src/main/java/ParseString.java
@@ -1,0 +1,8 @@
+package com.td.HttpServer;
+
+public class ParseString implements IParser {
+
+  public String[] parse(String request) {
+    return request.split("\\s+");
+  }
+}

--- a/src/main/java/RequestHandler.java
+++ b/src/main/java/RequestHandler.java
@@ -2,13 +2,13 @@ package com.td.HttpServer;
 
 public class RequestHandler {
 
-  Validator httpVerifier;
+  IValidator httpVerifier;
 
-  public RequestHandler(Validator verifier) {
+  public RequestHandler(IValidator verifier) {
     httpVerifier = verifier;
   }
 
-  public String processRequest(HttpProtocal request) {
+  public String processRequest(String[] request) {
     if (httpVerifier.isValid(request) == true ) {
       return "200";
     } else {

--- a/src/main/java/RequestHandler.java
+++ b/src/main/java/RequestHandler.java
@@ -10,9 +10,9 @@ public class RequestHandler {
 
   public String processRequest(String[] request) {
     if (httpVerifier.isValid(request) == true ) {
-      return "200";
+      return "HTTP/1.1 200 OK\r\n\r\nValid Http Request";
     } else {
-      return "400";
+      return "HTTP/1.0 400 Bad Request";
     }
   }
 }

--- a/src/main/java/RequestHandler.java
+++ b/src/main/java/RequestHandler.java
@@ -12,7 +12,7 @@ public class RequestHandler {
     if (httpVerifier.isValid(request) == true ) {
       return "HTTP/1.1 200 OK\r\n\r\nValid Http Request";
     } else {
-      return "HTTP/1.0 400 Bad Request";
+      return "HTTP/1.1 400 Bad Request";
     }
   }
 }

--- a/src/main/java/Validator.java
+++ b/src/main/java/Validator.java
@@ -1,7 +1,0 @@
-package com.td.HttpServer;
-
-public interface Validator {
-
-  public boolean isValid(HttpProtocal request);
-
-}

--- a/src/test/java/HttpVerifierTest.java
+++ b/src/test/java/HttpVerifierTest.java
@@ -4,86 +4,68 @@ public class HttpVerifierTest extends junit.framework.TestCase {
 
   HttpVerifier checker;
 
-  class MockHttpRequest implements HttpProtocal {
-    private String method;
-    private String path;
-    private String version;
-
-    public MockHttpRequest(String method_, String path_, String version_) {
-      method = method_;
-      path = path_;
-      version = version_;
-    }
-
-    public String method() { return method; }
-    public String path() { return path; }
-    public String version() { return version; }
-    public String requestLine() { return " "; }
-  }
-
-
-protected void setUp() {
+  protected void setUp() {
     checker = new HttpVerifier();
   }
 
   // Tesing invalid requests
   public void testInvalidRequestType() {
-    MockHttpRequest request = new MockHttpRequest("NOT", "/", "HTTP/1.1");
+    String[] request = { "NOT", "/", "HTTP/1.1" };
     assertFalse(checker.isValid(request));
   }
 
   public void testInvalidVersion() {
-    MockHttpRequest request = new MockHttpRequest("GET", "/", "FTP/1.1");
+    String[] request = {"GET", "/", "FTP/1.1"};
     assertFalse(checker.isValid(request));
   }
   public void testInvalidPath() {
-    MockHttpRequest request = new MockHttpRequest("GET", "G", "HTTP/1.1");
+    String[] request = { "GET", "G", "HTTP/1.1" };
     assertFalse(checker.isValid(request));
   }
 
   // Testing for each valid request type
   public void testForGetRequest() {
-    MockHttpRequest request = new MockHttpRequest("GET", "/", "HTTP/1.1");
+    String[] request = { "GET", "/", "HTTP/1.1" };
     assertTrue(checker.isValid(request));
   }
 
   public void testForHeadRequest() {
-    MockHttpRequest request = new MockHttpRequest("HEAD", "/", "HTTP/1.1");
+    String[] request = { "HEAD", "/", "HTTP/1.1" };
     assertTrue(checker.isValid(request));
   }
 
   public void testForPostRequest() {
-    MockHttpRequest request = new MockHttpRequest("POST", "/", "HTTP/1.1");
+    String[] request = { "POST", "/", "HTTP/1.1" };
     assertTrue(checker.isValid(request));
   }
 
   public void testForPutRequest() {
-    MockHttpRequest request = new MockHttpRequest("PUT", "/", "HTTP/1.1");
+    String[] request = { "PUT", "/", "HTTP/1.1" };
     assertTrue(checker.isValid(request));
   }
 
   public void testForDeleteRequest() {
-    MockHttpRequest request = new MockHttpRequest("DELETE", "/", "HTTP/1.1");
+    String[] request = { "DELETE", "/", "HTTP/1.1" };
     assertTrue(checker.isValid(request));
   }
 
   public void testForTraceRequest() {
-    MockHttpRequest request = new MockHttpRequest("TRACE", "/", "HTTP/1.1");
+    String[] request = { "TRACE", "/", "HTTP/1.1" };
     assertTrue(checker.isValid(request));
   }
 
   public void testForOptionsRequest() {
-    MockHttpRequest request = new MockHttpRequest("OPTIONS", "/", "HTTP/1.1");
+    String[] request = { "OPTIONS", "/", "HTTP/1.1" };
     assertTrue(checker.isValid(request));
   }
 
   public void testForConnectRequest() {
-    MockHttpRequest request = new MockHttpRequest("CONNECT", "/", "HTTP/1.1");
+    String[] request = { "CONNECT", "/", "HTTP/1.1" };
     assertTrue(checker.isValid(request));
   }
 
   public void testForPatchRequest() {
-    MockHttpRequest request = new MockHttpRequest("PATCH", "/", "HTTP/1.1");
+    String[] request = { "PATCH", "/", "HTTP/1.1" };
     assertTrue(checker.isValid(request));
   }
 }

--- a/src/test/java/HttpVerifierTest.java
+++ b/src/test/java/HttpVerifierTest.java
@@ -23,6 +23,16 @@ public class HttpVerifierTest extends junit.framework.TestCase {
     assertFalse(checker.isValid(request));
   }
 
+  public void testOnlyOneItemInRequestArray() {
+    String[] request = { "GET" };
+    assertFalse(checker.isValid(request));
+  }
+
+  public void testEmptyRequestArray() {
+    String[] request = { };
+    assertFalse(checker.isValid(request));
+  }
+
   // Testing for each valid request type
   public void testForGetRequest() {
     String[] request = { "GET", "/", "HTTP/1.1" };

--- a/src/test/java/ParseStringTest.java
+++ b/src/test/java/ParseStringTest.java
@@ -1,0 +1,25 @@
+import com.td.HttpServer.*;
+
+public class ParseStringTest extends junit.framework.TestCase {
+
+  String testString = "This is a test String";
+  String results[] = null;
+  ParseString parser;
+
+  protected void setUp() {
+    parser = new ParseString();
+    results = parser.parse(testString);
+  }
+
+  public void testCorrectLengthArray() {
+    assertEquals(5, results.length);
+  }
+
+  public void testFirstParameter() {
+    assertEquals("This", results[0]);
+  }
+
+  public void testSecondParameter() {
+    assertEquals("is", results[1]);
+  }
+}

--- a/src/test/java/ParseStringTest.java
+++ b/src/test/java/ParseStringTest.java
@@ -2,7 +2,7 @@ import com.td.HttpServer.*;
 
 public class ParseStringTest extends junit.framework.TestCase {
 
-  String testString = "This is a test String";
+  String testString = "This\nis\ra\ttest String";
   String results[] = null;
   ParseString parser;
 

--- a/src/test/java/RequestHandlerTest.java
+++ b/src/test/java/RequestHandlerTest.java
@@ -1,44 +1,37 @@
 import com.td.HttpServer.*;
 
-class MockRequest implements HttpProtocal {
-  public String method() { return " "; }
-  public String path() { return " "; }
-  public String version() { return " "; }
-  public String requestLine() { return " "; }
-}
-
-class MockVerifierValid implements Validator {
-  public boolean isValid(HttpProtocal request) {
+class MockVerifierValid implements IValidator {
+  public boolean isValid(String[] request) {
     return true;
   }
 }
 
-class MockVerifierInvalid implements Validator {
-  public boolean isValid(HttpProtocal request) {
+class MockVerifierInvalid implements IValidator {
+  public boolean isValid(String[] request) {
     return false;
   }
 }
-
 public class RequestHandlerTest extends junit.framework.TestCase {
-    RequestHandler handlerValid;
-    RequestHandler handlerInvalid;
-    MockVerifierValid valid;
-    MockVerifierInvalid invalid;
-    MockRequest request;
+
+
+  RequestHandler handler;
+  MockVerifierValid valid;
+  MockVerifierInvalid invalid;
+  String[] request = { "Dummy" };
+
 
   protected void setUp() {
     valid = new MockVerifierValid();
     invalid = new MockVerifierInvalid();
-    handlerValid = new RequestHandler(valid);
-    handlerInvalid = new RequestHandler(invalid);
-    request = new MockRequest();
   }
 
   public void testValidRequest() {
-    assertEquals("200", handlerValid.processRequest(request));
+    handler = new RequestHandler(valid);
+    assertEquals("200", handler.processRequest(request));
   }
 
   public void testInvalidRequest() {
-    assertEquals("400", handlerInvalid.processRequest(request));
+    handler = new RequestHandler(invalid);
+    assertEquals("400", handler.processRequest(request));
   }
 }

--- a/src/test/java/RequestHandlerTest.java
+++ b/src/test/java/RequestHandlerTest.java
@@ -27,11 +27,13 @@ public class RequestHandlerTest extends junit.framework.TestCase {
 
   public void testValidRequest() {
     handler = new RequestHandler(valid);
-    assertEquals("200", handler.processRequest(request));
+    String response = handler.processRequest(request);
+    assert(response.contains("200"));
   }
 
   public void testInvalidRequest() {
     handler = new RequestHandler(invalid);
-    assertEquals("400", handler.processRequest(request));
+    String response = handler.processRequest(request);
+    assert(response.contains("400"));
   }
 }


### PR DESCRIPTION
Fixed problem of HttpRequest object being able to be created from an invalid HttpRequest.
The ClientConnection now returns a String[] instead of a String.
The HttpServerRunner no longer creates the HttpRequest object.
The RequestHandler uses the validator to check if the request is valid. 
The RequestValidator now takes in a String[] and checks that the RequestLine is valid.

Currently the RequestHandler just returns HTTP/1.1 200 OK if the request is valid. 
In the future it will instead create an HttpRequest object and send that object to the proper request type handler.
