### PR TITLE
Made method in HttpResponse to build a byte[]

### DIFF
--- a/src/main/java/io/HttpReaderWriter.java
+++ b/src/main/java/io/HttpReaderWriter.java
@@ -28,11 +28,7 @@ public class HttpReaderWriter {
   }
 
   public void sendHttpResponse(HttpResponse response)throws IOException {
-    sendMessage(response.responseLine());
-    sendMessage("\n");
-    sendMessage(response.headers());
-    sendMessage("\r\n");
-    sendMessage(response.body());
+    sendMessage(response.responseBytes());
     socketIO.closeClientConnection();
   }
 

--- a/src/main/java/response/HttpResponse.java
+++ b/src/main/java/response/HttpResponse.java
@@ -1,17 +1,38 @@
 package com.td.HttpServer;
 
 import java.util.*;
+import java.io.*;
 
 public class HttpResponse {
 
   private String responseLine;
   private byte[] body;
   private HashMap<String, String> headers;
+  private final byte[] NEWLINE = "\r\n".getBytes();
 
   public HttpResponse(String responseLine, byte[] body, HashMap<String, String> headers) {
     this.responseLine = responseLine;
     this.body = body;
     this.headers = headers;
+  }
+
+  public byte[] responseBytes() {
+    ByteArrayOutputStream rtnStream = new ByteArrayOutputStream();
+    writeToByteArrayOS(rtnStream, responseLine());
+    writeToByteArrayOS(rtnStream, NEWLINE);
+    writeToByteArrayOS(rtnStream, headers());
+    writeToByteArrayOS(rtnStream, NEWLINE);
+    writeToByteArrayOS(rtnStream, body());
+    return rtnStream.toByteArray();
+  }
+
+  private void writeToByteArrayOS(ByteArrayOutputStream os, String toWrite) {
+    byte[] bytesToWrite = toWrite.getBytes();
+    writeToByteArrayOS(os, bytesToWrite);
+  }
+
+  private void writeToByteArrayOS(ByteArrayOutputStream os, byte[] bytesToWrite) {
+    os.write(bytesToWrite, 0, bytesToWrite.length);
   }
 
   public byte[] body() {


### PR DESCRIPTION
HttpReaderWriter no longer has to be responsible for sending the correct parts of the response. The HttpResponse class now can build a proper byte[] and give that to the HttpReaderWriter.
