### PR TITLE
Content length header consolidation

### DIFF
--- a/src/main/java/ContentType.java
+++ b/src/main/java/ContentType.java
@@ -1,0 +1,10 @@
+package com.td.HttpServer;
+
+public class ContentType {
+  public static final String html = "text/html";
+  public static final String text = "text/plain";
+  public static final String jpg = "image/jpeg";
+  public static final String gif = "image/gif";
+  public static final String pdf = "application/pdf";
+  public static final String download = "application/force-download";
+}

--- a/src/main/java/HandlerRouter.java
+++ b/src/main/java/HandlerRouter.java
@@ -5,11 +5,9 @@ import java.util.*;
 public class HandlerRouter implements IHandlerRouter {
 
   private IFileIO fileIO;
-  private ContentTypeForFileExtension contentTypeForFileExtension;
   private DirListHtml dirListHtml;
 
   public HandlerRouter(IFileIO fileIO) {
-    this.contentTypeForFileExtension = new ContentTypeForFileExtension();
     this.dirListHtml = new DirListHtml();
     this.fileIO = fileIO;
   }
@@ -29,7 +27,7 @@ public class HandlerRouter implements IHandlerRouter {
 
   private Ihandler selectGetHandler(String path) {
     if (fileIO.isFile(path)) {
-      return new HandlerGetFileContents(path, fileIO, contentTypeForFileExtension);
+      return new HandlerGetFileContents(path, fileIO);
     } else if (fileIO.isDirectory(path)) {
       return new HandlerGetDirectoryContents(path, fileIO, dirListHtml);
     } else {

--- a/src/main/java/HandlerRouter.java
+++ b/src/main/java/HandlerRouter.java
@@ -5,11 +5,11 @@ import java.util.*;
 public class HandlerRouter implements IHandlerRouter {
 
   private IFileIO fileIO;
-  private ResponseHeadersForContent responseHeadersForContent;
+  private ContentTypeForFileExtension contentTypeForFileExtension;
   private DirListHtml dirListHtml;
 
   public HandlerRouter(IFileIO fileIO) {
-    this.responseHeadersForContent = new ResponseHeadersForContent();
+    this.contentTypeForFileExtension = new ContentTypeForFileExtension();
     this.dirListHtml = new DirListHtml();
     this.fileIO = fileIO;
   }
@@ -29,7 +29,7 @@ public class HandlerRouter implements IHandlerRouter {
 
   private Ihandler selectGetHandler(String path) {
     if (fileIO.isFile(path)) {
-      return new HandlerGetFileContents(path, fileIO, responseHeadersForContent);
+      return new HandlerGetFileContents(path, fileIO, contentTypeForFileExtension);
     } else if (fileIO.isDirectory(path)) {
       return new HandlerGetDirectoryContents(path, fileIO, dirListHtml);
     } else {

--- a/src/main/java/handlers/HandlerBadRequest.java
+++ b/src/main/java/handlers/HandlerBadRequest.java
@@ -5,7 +5,7 @@ public class HandlerBadRequest implements Ihandler {
   public HttpResponse generateResponse() {
     HttpResponse rtnResponse = new HttpResponse();
     rtnResponse.setResponseCode(400);
-    rtnResponse.setBody("Bad Request");
+    rtnResponse.setBody("Bad Request", "test/plain");
     return rtnResponse;
   }
 }

--- a/src/main/java/handlers/HandlerBadRequest.java
+++ b/src/main/java/handlers/HandlerBadRequest.java
@@ -5,7 +5,7 @@ public class HandlerBadRequest implements Ihandler {
   public HttpResponse generateResponse() {
     HttpResponse rtnResponse = new HttpResponse();
     rtnResponse.setResponseCode(400);
-    rtnResponse.setBody("Bad Request", "text/plain");
+    rtnResponse.setBody("Bad Request", ContentType.text);
     return rtnResponse;
   }
 }

--- a/src/main/java/handlers/HandlerBadRequest.java
+++ b/src/main/java/handlers/HandlerBadRequest.java
@@ -5,7 +5,7 @@ public class HandlerBadRequest implements Ihandler {
   public HttpResponse generateResponse() {
     HttpResponse rtnResponse = new HttpResponse();
     rtnResponse.setResponseCode(400);
-    rtnResponse.setBody("Bad Request", "test/plain");
+    rtnResponse.setBody("Bad Request", "text/plain");
     return rtnResponse;
   }
 }

--- a/src/main/java/handlers/HandlerFileNotFound.java
+++ b/src/main/java/handlers/HandlerFileNotFound.java
@@ -5,7 +5,7 @@ public class HandlerFileNotFound implements Ihandler {
   public HttpResponse generateResponse() {
     HttpResponse rtnResponse = new HttpResponse();
     rtnResponse.setResponseCode(404);
-    rtnResponse.setBody("File not Found", "text/plain");
+    rtnResponse.setBody("File not Found", ContentType.text);
     return rtnResponse;
   }
 }

--- a/src/main/java/handlers/HandlerFileNotFound.java
+++ b/src/main/java/handlers/HandlerFileNotFound.java
@@ -5,7 +5,7 @@ public class HandlerFileNotFound implements Ihandler {
   public HttpResponse generateResponse() {
     HttpResponse rtnResponse = new HttpResponse();
     rtnResponse.setResponseCode(404);
-    rtnResponse.setBody("File not Found");
+    rtnResponse.setBody("File not Found", "plain/text");
     return rtnResponse;
   }
 }

--- a/src/main/java/handlers/HandlerFileNotFound.java
+++ b/src/main/java/handlers/HandlerFileNotFound.java
@@ -5,7 +5,7 @@ public class HandlerFileNotFound implements Ihandler {
   public HttpResponse generateResponse() {
     HttpResponse rtnResponse = new HttpResponse();
     rtnResponse.setResponseCode(404);
-    rtnResponse.setBody("File not Found", "plain/text");
+    rtnResponse.setBody("File not Found", "text/plain");
     return rtnResponse;
   }
 }

--- a/src/main/java/handlers/HandlerGetDirectoryContents.java
+++ b/src/main/java/handlers/HandlerGetDirectoryContents.java
@@ -31,7 +31,5 @@ public class HandlerGetDirectoryContents implements Ihandler {
 
   public void addHeaders(HttpResponse response, byte[] body) {
     response.addHeader("Content-Type", "text/html");
-    String contentLength = Integer.toString(body.length);
-    response.addHeader("Content-Length", contentLength);
   }
 }

--- a/src/main/java/handlers/HandlerGetDirectoryContents.java
+++ b/src/main/java/handlers/HandlerGetDirectoryContents.java
@@ -18,11 +18,11 @@ public class HandlerGetDirectoryContents implements Ihandler {
     try {
       String[] fileList = fileIO.getFiles(path);
       byte[] body = dirListHtml.buildHtmlPage(path, fileList);
-      rtnResponse.setBody(body, "text/html");
+      rtnResponse.setBody(body, ContentType.html);
     }
     catch (IOException e) {
       e.printStackTrace();
-      rtnResponse.setBody("IOException", "text/plain");
+      rtnResponse.setBody("IOException", ContentType.text);
       rtnResponse.setResponseCode(404);
     }
     return rtnResponse;

--- a/src/main/java/handlers/HandlerGetDirectoryContents.java
+++ b/src/main/java/handlers/HandlerGetDirectoryContents.java
@@ -18,18 +18,13 @@ public class HandlerGetDirectoryContents implements Ihandler {
     try {
       String[] fileList = fileIO.getFiles(path);
       byte[] body = dirListHtml.buildHtmlPage(path, fileList);
-      rtnResponse.setBody(body);
-      addHeaders(rtnResponse, body);
+      rtnResponse.setBody(body, "text/html");
     }
     catch (IOException e) {
       e.printStackTrace();
-      rtnResponse.setBody("IOException");
+      rtnResponse.setBody("IOException", "text/plain");
       rtnResponse.setResponseCode(404);
     }
     return rtnResponse;
-  }
-
-  public void addHeaders(HttpResponse response, byte[] body) {
-    response.addHeader("Content-Type", "text/html");
   }
 }

--- a/src/main/java/handlers/HandlerGetFileContents.java
+++ b/src/main/java/handlers/HandlerGetFileContents.java
@@ -3,13 +3,13 @@ package com.td.HttpServer;
 import java.io.IOException;
 
 public class HandlerGetFileContents implements Ihandler {
+  private ContentTypeForFileExtension contentTypeForFileExtension;
   private IFileIO fileIO;
-  private ContentTypeForFileExtension contentType;
   private String path;
 
-  public HandlerGetFileContents(String path, IFileIO fileIO, ContentTypeForFileExtension contentType) {
+  public HandlerGetFileContents(String path, IFileIO fileIO) {
+    this.contentTypeForFileExtension = new ContentTypeForFileExtension();
     this.path = path;
-    this.contentType = contentType;
     this.fileIO = fileIO;
   }
 
@@ -17,7 +17,7 @@ public class HandlerGetFileContents implements Ihandler {
     HttpResponse rtnResponse = new HttpResponse();
     try {
       byte[] body = fileIO.getContent(path);
-      rtnResponse.setBody(body, contentType.getContentType(path));
+      rtnResponse.setBody(body, contentTypeForFileExtension.getContentType(path));
     }
     catch (IOException e) {
       e.printStackTrace();

--- a/src/main/java/handlers/HandlerGetFileContents.java
+++ b/src/main/java/handlers/HandlerGetFileContents.java
@@ -4,12 +4,12 @@ import java.io.IOException;
 
 public class HandlerGetFileContents implements Ihandler {
   private IFileIO fileIO;
-  private ResponseHeadersForContent responseHeaders;
+  private ContentTypeForFileExtension contentType;
   private String path;
 
-  public HandlerGetFileContents(String path, IFileIO fileIO, ResponseHeadersForContent responseHeaders) {
+  public HandlerGetFileContents(String path, IFileIO fileIO, ContentTypeForFileExtension contentType) {
     this.path = path;
-    this.responseHeaders = responseHeaders;
+    this.contentType = contentType;
     this.fileIO = fileIO;
   }
 
@@ -17,12 +17,11 @@ public class HandlerGetFileContents implements Ihandler {
     HttpResponse rtnResponse = new HttpResponse();
     try {
       byte[] body = fileIO.getContent(path);
-      rtnResponse.setBody(body);
-      rtnResponse.addHeaders(responseHeaders.getHeaders(body, path));
+      rtnResponse.setBody(body, contentType.getContentType(path));
     }
     catch (IOException e) {
       e.printStackTrace();
-      rtnResponse.setBody("IOException");
+      rtnResponse.setBody("IOException", "text/plain");
       rtnResponse.setResponseCode(404);
     }
     return rtnResponse;

--- a/src/main/java/handlers/HandlerGetFileContents.java
+++ b/src/main/java/handlers/HandlerGetFileContents.java
@@ -21,7 +21,7 @@ public class HandlerGetFileContents implements Ihandler {
     }
     catch (IOException e) {
       e.printStackTrace();
-      rtnResponse.setBody("IOException", "text/plain");
+      rtnResponse.setBody("IOException", ContentType.text);
       rtnResponse.setResponseCode(404);
     }
     return rtnResponse;

--- a/src/main/java/handlers/HandlerPostFileContents.java
+++ b/src/main/java/handlers/HandlerPostFileContents.java
@@ -22,7 +22,7 @@ public class HandlerPostFileContents implements Ihandler {
     }
     catch (IOException e) {
       e.printStackTrace();
-      rtnResponse.setBody("IOException");
+      rtnResponse.setBody("IOException", "text/plain");
       rtnResponse.setResponseCode(404);
     }
     return rtnResponse;

--- a/src/main/java/handlers/HandlerPostFileContents.java
+++ b/src/main/java/handlers/HandlerPostFileContents.java
@@ -22,7 +22,7 @@ public class HandlerPostFileContents implements Ihandler {
     }
     catch (IOException e) {
       e.printStackTrace();
-      rtnResponse.setBody("IOException", "text/plain");
+      rtnResponse.setBody("IOException", ContentType.text);
       rtnResponse.setResponseCode(404);
     }
     return rtnResponse;

--- a/src/main/java/handlers/HandlerUnprocessableEntity.java
+++ b/src/main/java/handlers/HandlerUnprocessableEntity.java
@@ -10,8 +10,7 @@ public class HandlerUnprocessableEntity implements Ihandler {
   public HttpResponse generateResponse() {
     HttpResponse rtnResponse = new HttpResponse();
     rtnResponse.setResponseCode(422);
-    rtnResponse.addHeader("Content-Type", "text/plain");
-    rtnResponse.setBody(message);
+    rtnResponse.setBody(message, "text/plain");
     return rtnResponse;
   }
 }

--- a/src/main/java/handlers/HandlerUnprocessableEntity.java
+++ b/src/main/java/handlers/HandlerUnprocessableEntity.java
@@ -10,7 +10,7 @@ public class HandlerUnprocessableEntity implements Ihandler {
   public HttpResponse generateResponse() {
     HttpResponse rtnResponse = new HttpResponse();
     rtnResponse.setResponseCode(422);
-    rtnResponse.setBody(message, "text/plain");
+    rtnResponse.setBody(message, ContentType.text);
     return rtnResponse;
   }
 }

--- a/src/main/java/response/ContentTypeForFileExtension.java
+++ b/src/main/java/response/ContentTypeForFileExtension.java
@@ -10,18 +10,18 @@ public class ContentTypeForFileExtension {
     buildContentTypeMap();
   }
   public String getContentType(String fileName) {
-    return contentTypeMap.getOrDefault(getFileExtension(fileName), "application/force-download");
+    return contentTypeMap.getOrDefault(getFileExtension(fileName), ContentType.download);
   }
 
   private void buildContentTypeMap() {
     contentTypeMap = new HashMap<String, String>();
-    contentTypeMap.put(".htm", "text/html");
-    contentTypeMap.put(".html", "text/html");
-    contentTypeMap.put(".txt", "text/plain");
-    contentTypeMap.put(".jpg", "image/jpeg");
-    contentTypeMap.put(".jpeg", "image/jpeg");
-    contentTypeMap.put(".gif", "image/gif");
-    contentTypeMap.put(".pdf", "application/pdf");
+    contentTypeMap.put(".htm", ContentType.html);
+    contentTypeMap.put(".html", ContentType.html);
+    contentTypeMap.put(".txt", ContentType.text);
+    contentTypeMap.put(".jpg", ContentType.jpg);
+    contentTypeMap.put(".jpeg", ContentType.jpg);
+    contentTypeMap.put(".gif", ContentType.gif);
+    contentTypeMap.put(".pdf", ContentType.pdf);
   }
 
   private String getFileExtension(String fileName) {

--- a/src/main/java/response/ContentTypeForFileExtension.java
+++ b/src/main/java/response/ContentTypeForFileExtension.java
@@ -1,19 +1,16 @@
 package com.td.HttpServer;
 
-import java.util.*;
+import java.util.HashMap;
 
-public class ResponseHeadersForContent {
+public class ContentTypeForFileExtension {
 
   private HashMap<String, String> contentTypeMap;
 
-  public ResponseHeadersForContent() {
+  public ContentTypeForFileExtension() {
     buildContentTypeMap();
   }
-
-  public HashMap<String, String> getHeaders (byte[] body, String path) {
-    HashMap<String, String> rtnHeaders = new HashMap<String, String>();
-    rtnHeaders.put("Content-Type", contentType(path));
-    return rtnHeaders;
+  public String getContentType(String fileName) {
+    return contentTypeMap.getOrDefault(getFileExtension(fileName), "application/force-download");
   }
 
   private void buildContentTypeMap() {
@@ -25,10 +22,6 @@ public class ResponseHeadersForContent {
     contentTypeMap.put(".jpeg", "image/jpeg");
     contentTypeMap.put(".gif", "image/gif");
     contentTypeMap.put(".pdf", "application/pdf");
-  }
-
-  private String contentType(String fileName) {
-    return contentTypeMap.getOrDefault(getFileExtension(fileName), "application/force-download");
   }
 
   private String getFileExtension(String fileName) {

--- a/src/main/java/response/HttpResponse.java
+++ b/src/main/java/response/HttpResponse.java
@@ -25,10 +25,11 @@ public class HttpResponse {
 
   public void setBody(byte[] body) {
     this.body = body;
+    addHeader("Content-Length", contentLength(this.body));
   }
 
   public void setBody(String body) {
-    this.body = body.getBytes();
+    setBody(body.getBytes());
   }
 
   public byte[] body() {
@@ -49,5 +50,9 @@ public class HttpResponse {
 
   public String getValueForHeader(String key) {
     return headers.get(key);
+  }
+
+  private String contentLength(byte[] body) {
+    return Integer.toString(body.length);
   }
 }

--- a/src/main/java/response/HttpResponse.java
+++ b/src/main/java/response/HttpResponse.java
@@ -23,13 +23,14 @@ public class HttpResponse {
     return responseCode;
   }
 
-  public void setBody(byte[] body) {
+  public void setBody(byte[] body, String contentType) {
     this.body = body;
     addHeader("Content-Length", contentLength(this.body));
+    addHeader("Content-Type", contentType);
   }
 
-  public void setBody(String body) {
-    setBody(body.getBytes());
+  public void setBody(String body, String contentType) {
+    setBody(body.getBytes(), contentType);
   }
 
   public byte[] body() {

--- a/src/main/java/response/ResponseHeadersForContent.java
+++ b/src/main/java/response/ResponseHeadersForContent.java
@@ -13,7 +13,6 @@ public class ResponseHeadersForContent {
   public HashMap<String, String> getHeaders (byte[] body, String path) {
     HashMap<String, String> rtnHeaders = new HashMap<String, String>();
     rtnHeaders.put("Content-Type", contentType(path));
-    rtnHeaders.put("Content-Length", contentLength(body));
     return rtnHeaders;
   }
 
@@ -26,10 +25,6 @@ public class ResponseHeadersForContent {
     contentTypeMap.put(".jpeg", "image/jpeg");
     contentTypeMap.put(".gif", "image/gif");
     contentTypeMap.put(".pdf", "application/pdf");
-  }
-
-  private String contentLength(byte[] body) {
-    return Integer.toString(body.length);
   }
 
   private String contentType(String fileName) {

--- a/src/test/java/ContentTypeForFileExtensionTest.java
+++ b/src/test/java/ContentTypeForFileExtensionTest.java
@@ -1,0 +1,44 @@
+import com.td.HttpServer.ContentTypeForFileExtension;
+
+public class ContentTypeForFileExtensionTest extends junit.framework.TestCase {
+
+  private ContentTypeForFileExtension contentType;
+
+  protected void setUp() {
+    contentType = new ContentTypeForFileExtension();
+  }
+
+  public void testContentTypeIsTextHtmlForHtml() {
+    assertEquals("text/html", contentType.getContentType("/something.html"));
+  }
+
+  public void testContentTypeIsTextHtmlForHtm() {
+    assertEquals("text/html", contentType.getContentType("/something.htm"));
+  }
+
+  public void testContentTypeIsTextPlainForTxtFile() {
+    assertEquals("text/plain", contentType.getContentType("/something.txt"));
+  }
+
+  public void testContentTypeIsImageJpegForJpg() {
+    assertEquals("image/jpeg", contentType.getContentType("/something.jpg"));
+  }
+
+  public void testContentTypeIsImageJpegForJpeg() {
+    assertEquals("image/jpeg", contentType.getContentType("/something.jpeg"));
+  }
+
+  public void testContentTypeIsImageGifForGif() {
+    assertEquals("image/gif", contentType.getContentType("/something.gif"));
+  }
+
+  public void testContentTypeIsPdfForPdf() {
+    assertEquals("application/pdf", contentType.getContentType("something.pdf"));
+  }
+
+  public void testContentTypeIsApplicationForceDownlaodForDefault() {
+    assertEquals("application/force-download", contentType.getContentType("/something.other"));
+  }
+
+
+}

--- a/src/test/java/HandlerGetFileContentsTest.java
+++ b/src/test/java/HandlerGetFileContentsTest.java
@@ -6,42 +6,40 @@ import java.io.IOException;
 public class HandlerGetFileContentsTest extends junit.framework.TestCase {
 
   HandlerGetFileContents handler;
-  ContentTypeForFileExtension contentTypeForFileExtension;
   HttpRequest request;
   HttpResponse response;
   MockFileIO mockFileIO;
 
   protected void setUp() {
     mockFileIO = new MockFileIO();
-    contentTypeForFileExtension = new ContentTypeForFileExtension();
     mockFileIO.setIsFileTrue();
     mockFileIO.setIsDirectoryFalse();
   }
 
   public void testGenerateOkResponseDefaultPath() {
     String path = "/";
-    handler = new HandlerGetFileContents(path, mockFileIO, contentTypeForFileExtension);
+    handler = new HandlerGetFileContents(path, mockFileIO);
     response = handler.generateResponse();
     assertEquals(response.responseCode(), 200);
   }
 
   public void testGenerateOkResponseValidFile() {
     String path = "/something.txt";
-    handler = new HandlerGetFileContents(path, mockFileIO, contentTypeForFileExtension);
+    handler = new HandlerGetFileContents(path, mockFileIO);
     response = handler.generateResponse();
     assertEquals(response.responseCode(), 200);
   }
 
   public void testGenerateNotFoundResponseforInvalidFile() {
     String path = "/throwIOException";
-    handler = new HandlerGetFileContents(path, mockFileIO, contentTypeForFileExtension);
+    handler = new HandlerGetFileContents(path, mockFileIO);
     response = handler.generateResponse();
     assertEquals(response.responseCode(), 404);
   }
 
   public void testContentTypeIsTextHtmlForTxtFile() {
     String path = "/something.txt";
-    handler = new HandlerGetFileContents(path, mockFileIO, contentTypeForFileExtension);
+    handler = new HandlerGetFileContents(path, mockFileIO);
     response = handler.generateResponse();
     assertEquals(response.headers().get("Content-Type"), "text/plain");
   }

--- a/src/test/java/HandlerGetFileContentsTest.java
+++ b/src/test/java/HandlerGetFileContentsTest.java
@@ -45,25 +45,4 @@ public class HandlerGetFileContentsTest extends junit.framework.TestCase {
     response = handler.generateResponse();
     assertEquals(response.headers().get("Content-Type"), "text/plain");
   }
-
-  public void testContentTypeIsImageJpegForJpg() {
-    String path = "/something.jpg";
-    handler = new HandlerGetFileContents(path, mockFileIO, contentTypeForFileExtension);
-    response = handler.generateResponse();
-    assertEquals(response.headers().get("Content-Type"), "image/jpeg");
-  }
-
-  public void testContentTypeIsImageGifForGif() {
-    String path = "/something.gif";
-    handler = new HandlerGetFileContents(path, mockFileIO, contentTypeForFileExtension);
-    response = handler.generateResponse();
-    assertEquals(response.headers().get("Content-Type"), "image/gif");
-  }
-
-  public void testContentTypeIsPdfForPdf() {
-    String path = "/something.pdf";
-    handler = new HandlerGetFileContents(path, mockFileIO, contentTypeForFileExtension);
-    response = handler.generateResponse();
-    assertEquals(response.headers().get("Content-Type"), "application/pdf");
-  }
 }

--- a/src/test/java/HandlerGetFileContentsTest.java
+++ b/src/test/java/HandlerGetFileContentsTest.java
@@ -6,63 +6,63 @@ import java.io.IOException;
 public class HandlerGetFileContentsTest extends junit.framework.TestCase {
 
   HandlerGetFileContents handler;
-  ResponseHeadersForContent responseHeadersForContent;
+  ContentTypeForFileExtension contentTypeForFileExtension;
   HttpRequest request;
   HttpResponse response;
   MockFileIO mockFileIO;
 
   protected void setUp() {
     mockFileIO = new MockFileIO();
-    responseHeadersForContent = new ResponseHeadersForContent();
+    contentTypeForFileExtension = new ContentTypeForFileExtension();
     mockFileIO.setIsFileTrue();
     mockFileIO.setIsDirectoryFalse();
   }
 
   public void testGenerateOkResponseDefaultPath() {
     String path = "/";
-    handler = new HandlerGetFileContents(path, mockFileIO, responseHeadersForContent);
+    handler = new HandlerGetFileContents(path, mockFileIO, contentTypeForFileExtension);
     response = handler.generateResponse();
     assertEquals(response.responseCode(), 200);
   }
 
   public void testGenerateOkResponseValidFile() {
     String path = "/something.txt";
-    handler = new HandlerGetFileContents(path, mockFileIO, responseHeadersForContent);
+    handler = new HandlerGetFileContents(path, mockFileIO, contentTypeForFileExtension);
     response = handler.generateResponse();
     assertEquals(response.responseCode(), 200);
   }
 
   public void testGenerateNotFoundResponseforInvalidFile() {
     String path = "/throwIOException";
-    handler = new HandlerGetFileContents(path, mockFileIO, responseHeadersForContent);
+    handler = new HandlerGetFileContents(path, mockFileIO, contentTypeForFileExtension);
     response = handler.generateResponse();
     assertEquals(response.responseCode(), 404);
   }
 
   public void testContentTypeIsTextHtmlForTxtFile() {
     String path = "/something.txt";
-    handler = new HandlerGetFileContents(path, mockFileIO, responseHeadersForContent);
+    handler = new HandlerGetFileContents(path, mockFileIO, contentTypeForFileExtension);
     response = handler.generateResponse();
     assertEquals(response.headers().get("Content-Type"), "text/plain");
   }
 
   public void testContentTypeIsImageJpegForJpg() {
     String path = "/something.jpg";
-    handler = new HandlerGetFileContents(path, mockFileIO, responseHeadersForContent);
+    handler = new HandlerGetFileContents(path, mockFileIO, contentTypeForFileExtension);
     response = handler.generateResponse();
     assertEquals(response.headers().get("Content-Type"), "image/jpeg");
   }
 
   public void testContentTypeIsImageGifForGif() {
     String path = "/something.gif";
-    handler = new HandlerGetFileContents(path, mockFileIO, responseHeadersForContent);
+    handler = new HandlerGetFileContents(path, mockFileIO, contentTypeForFileExtension);
     response = handler.generateResponse();
     assertEquals(response.headers().get("Content-Type"), "image/gif");
   }
 
   public void testContentTypeIsPdfForPdf() {
     String path = "/something.pdf";
-    handler = new HandlerGetFileContents(path, mockFileIO, responseHeadersForContent);
+    handler = new HandlerGetFileContents(path, mockFileIO, contentTypeForFileExtension);
     response = handler.generateResponse();
     assertEquals(response.headers().get("Content-Type"), "application/pdf");
   }

--- a/src/test/java/HttpResponseTest.java
+++ b/src/test/java/HttpResponseTest.java
@@ -15,19 +15,24 @@ public class HttpResponseTest extends junit.framework.TestCase {
   }
 
   public void testDefaultResponseLine() {
-    assertEquals(200, response.responseCode());
+    assertEquals(response.responseCode(), 200);
   }
 
   public void testGetHeaders() {
-    assertEquals("testValue", response.headers().get("testKey"));
+    assertEquals(response.headers().get("testKey"), "testValue");
   }
 
   public void testGetValue() {
-    assertEquals("testValue", response.getValueForHeader("testKey"));
+    assertEquals(response.getValueForHeader("testKey"), "testValue");
   }
 
   public void testAddHashMapToHeaders() {
     response.addHeaders(testMap);
-    assertEquals("value02", response.getValueForHeader("key02"));
+    assertEquals(response.getValueForHeader("key02"), "value02");
+  }
+
+  public void testContentLengthGetsSet() {
+    response.setBody("12345");
+    assertEquals(response.getValueForHeader("Content-Length"), "5");
   }
 }

--- a/src/test/java/HttpResponseTest.java
+++ b/src/test/java/HttpResponseTest.java
@@ -12,6 +12,7 @@ public class HttpResponseTest extends junit.framework.TestCase {
     testMap = new HashMap<String, String>();
     testMap.put("key01", "value01");
     testMap.put("key02", "value02");
+    response.setBody("12345", "text/plain");
   }
 
   public void testDefaultResponseLine() {
@@ -32,7 +33,10 @@ public class HttpResponseTest extends junit.framework.TestCase {
   }
 
   public void testContentLengthGetsSet() {
-    response.setBody("12345");
     assertEquals(response.getValueForHeader("Content-Length"), "5");
+  }
+
+  public void testContentTypeGetsSet() {
+    assertEquals(response.getValueForHeader("Content-Type"), "text/plain");
   }
 }

--- a/src/test/java/HttpResponseWriterTest.java
+++ b/src/test/java/HttpResponseWriterTest.java
@@ -15,10 +15,10 @@ public class HttpResponseWriterTest extends junit.framework.TestCase {
   }
 
   public void testGeneratedResponseSentOutToSocket() throws BadConnectionException {
-    response.setBody("This is the response body");
+    response.setBody("This is the response body", "text/plain");
     response.addHeader("Test/Header", "test value");
     response.addHeader("Test/Header2", "test value2");
-    String responseShouldBe = "HTTP/1.1 200 OK\r\nTest/Header: test value\r\nTest/Header2: test value2\r\nContent-Length: 25\r\n\r\nThis is the response body";
+    String responseShouldBe = "HTTP/1.1 200 OK\r\nTest/Header: test value\r\nTest/Header2: test value2\r\nContent-Length: 25\r\nContent-Type: text/plain\r\n\r\nThis is the response body";
     writer.sendHttpResponse(mockSocketIO, response);
     String responseGenerated = new String(mockSocketIO.getReceivedBytes());
     assertEquals(responseShouldBe, responseGenerated);

--- a/src/test/java/HttpResponseWriterTest.java
+++ b/src/test/java/HttpResponseWriterTest.java
@@ -16,9 +16,7 @@ public class HttpResponseWriterTest extends junit.framework.TestCase {
 
   public void testGeneratedResponseSentOutToSocket() throws BadConnectionException {
     response.setBody("This is the response body", "text/plain");
-    response.addHeader("Test/Header", "test value");
-    response.addHeader("Test/Header2", "test value2");
-    String responseShouldBe = "HTTP/1.1 200 OK\r\nTest/Header: test value\r\nTest/Header2: test value2\r\nContent-Length: 25\r\nContent-Type: text/plain\r\n\r\nThis is the response body";
+    String responseShouldBe = "HTTP/1.1 200 OK\r\nContent-Length: 25\r\nContent-Type: text/plain\r\n\r\nThis is the response body";
     writer.sendHttpResponse(mockSocketIO, response);
     String responseGenerated = new String(mockSocketIO.getReceivedBytes());
     assertEquals(responseShouldBe, responseGenerated);

--- a/src/test/java/HttpResponseWriterTest.java
+++ b/src/test/java/HttpResponseWriterTest.java
@@ -18,9 +18,9 @@ public class HttpResponseWriterTest extends junit.framework.TestCase {
     response.setBody("This is the response body");
     response.addHeader("Test/Header", "test value");
     response.addHeader("Test/Header2", "test value2");
-    String responseShouldBe = "HTTP/1.1 200 OK\r\nTest/Header: test value\r\nTest/Header2: test value2\r\n\r\nThis is the response body";
+    String responseShouldBe = "HTTP/1.1 200 OK\r\nTest/Header: test value\r\nTest/Header2: test value2\r\nContent-Length: 25\r\n\r\nThis is the response body";
     writer.sendHttpResponse(mockSocketIO, response);
     String responseGenerated = new String(mockSocketIO.getReceivedBytes());
-    assertEquals(responseGenerated, responseShouldBe);
+    assertEquals(responseShouldBe, responseGenerated);
   }
 }


### PR DESCRIPTION
This pull request ensures that the `Content-Type` and `Content-Length` headers get set anytime a `HttpResponse` has a body.
- Made is so that when setting the body of a `HttpResponse` that the `Content-Type` must be supplied. 
- The `HttpResponse` now sets the `Content-Type` header and figures out the `Content-Length` header. 

Prior to this change, each route would be responsible for making sure it set a `Content-Type` header and had to figure out the `Content-Length` itself and set that as well.
