### PR TITLE
Create a ICallable interface

### DIFF
--- a/src/main/java/httpResponse/HttpResponse.java
+++ b/src/main/java/httpResponse/HttpResponse.java
@@ -3,11 +3,19 @@ package com.td.HttpServer;
 import java.util.*;
 import java.io.*;
 
-public class HttpResponse {
+public class HttpResponse implements ICallable {
 
   private int responseCode;
   private byte[] body;
   private HashMap<String, String> headers;
+
+  public Object[] call() {
+    Object[] returnArray = new Object[3];
+    returnArray[0] = responseCode();
+    returnArray[1] = headers();
+    returnArray[2] = body();
+    return returnArray;
+  }
 
   public HttpResponse() {
     this.responseCode = 200;
@@ -19,7 +27,7 @@ public class HttpResponse {
     this.responseCode = code;
   }
 
-  public int responseCode() {
+  private int responseCode() {
     return responseCode;
   }
 
@@ -33,7 +41,7 @@ public class HttpResponse {
     setBody(body.getBytes(), contentType);
   }
 
-  public byte[] body() {
+  private byte[] body() {
     return body;
   }
 
@@ -45,7 +53,7 @@ public class HttpResponse {
     this.headers.putAll(headers);
   }
 
-  public HashMap<String, String> headers() {
+  private HashMap<String, String> headers() {
     return headers;
   }
 

--- a/src/main/java/httpResponse/HttpResponseWriter.java
+++ b/src/main/java/httpResponse/HttpResponseWriter.java
@@ -11,7 +11,7 @@ public class HttpResponseWriter implements IResponseWriter {
     buildResponseLineMap();
   }
 
-  public void sendHttpResponse(IClientSocketOutput client, HttpResponse response) throws BadConnectionException {
+  public void sendHttpResponse(IClientSocketOutput client, ICallable response) throws BadConnectionException {
     byte[] responseBytes = responseAsBytes(response);
     try {
       client.sendBytes(responseBytes);

--- a/src/main/java/httpResponse/HttpResponseWriter.java
+++ b/src/main/java/httpResponse/HttpResponseWriter.java
@@ -22,13 +22,18 @@ public class HttpResponseWriter implements IResponseWriter {
     }
   }
 
-  private byte[] responseAsBytes(HttpResponse response) {
+  private byte[] responseAsBytes(ICallable response) {
+    Object[] responseArray = response.call();
+    int responseCode = (int)responseArray[0];
+    HashMap<String, String> headers = (HashMap<String, String>)responseArray[1];
+    byte[] body = (byte[])responseArray[2];
+
     ByteArrayOutputStream rtnStream = new ByteArrayOutputStream();
-    writeToByteArrayOS(rtnStream, responseLine(response.responseCode()));
+    writeToByteArrayOS(rtnStream, responseLine(responseCode));
     writeToByteArrayOS(rtnStream, NEWLINE);
-    writeToByteArrayOS(rtnStream, headers(response.headers()));
+    writeToByteArrayOS(rtnStream, headers(headers));
     writeToByteArrayOS(rtnStream, NEWLINE);
-    writeToByteArrayOS(rtnStream, response.body());
+    writeToByteArrayOS(rtnStream, body);
     return rtnStream.toByteArray();
   }
 

--- a/src/main/java/httpResponse/ICallable.java
+++ b/src/main/java/httpResponse/ICallable.java
@@ -1,0 +1,5 @@
+package com.td.HttpServer;
+
+public interface ICallable {
+  public Object[] call();
+}

--- a/src/test/java/HandlerGetDirectoryContentsTest.java
+++ b/src/test/java/HandlerGetDirectoryContentsTest.java
@@ -1,6 +1,6 @@
 import com.td.HttpServer.*;
 import com.td.Mocks.*;
-
+import java.util.HashMap;
 
 public class HandlerGetDirectoryContentsTest extends junit.framework.TestCase {
 
@@ -9,6 +9,9 @@ public class HandlerGetDirectoryContentsTest extends junit.framework.TestCase {
   HttpResponse response;
   DirListHtml dirListHtml;
   MockFileIO mockFileIO;
+  int responseCode;
+  HashMap<String, String> headers;
+
 
   protected void setUp() {
     dirListHtml = new DirListHtml();
@@ -22,7 +25,7 @@ public class HandlerGetDirectoryContentsTest extends junit.framework.TestCase {
     String path = "/";
     handler = new HandlerGetDirectoryContents(path, mockFileIO, dirListHtml);
     response = handler.generateResponse();
-    String body = new String(response.body());
+    String body = new String((byte[])response.call()[2]);
     assert(body.contains("<a href=\"/file01\">file01</a>"));
   }
 
@@ -30,14 +33,16 @@ public class HandlerGetDirectoryContentsTest extends junit.framework.TestCase {
     String path = "/";
     handler = new HandlerGetDirectoryContents(path, mockFileIO, dirListHtml);
     response = handler.generateResponse();
-    assertEquals(200, response.responseCode());
+    int responseCode = (int)response.call()[0];
+    assertEquals(responseCode, 200);
   }
 
   public void testGenerateNotFoundCodeForIOException() {
     String path = "/throwIOException";
     handler = new HandlerGetDirectoryContents(path, mockFileIO, dirListHtml);
     response = handler.generateResponse();
-    assertEquals(404, response.responseCode());
+    int responseCode = (int)response.call()[0];
+    assertEquals(responseCode, 404);
   }
 
   public void testContentType() {

--- a/src/test/java/HandlerGetFileContentsTest.java
+++ b/src/test/java/HandlerGetFileContentsTest.java
@@ -9,7 +9,7 @@ public class HandlerGetFileContentsTest extends junit.framework.TestCase {
   HttpRequest request;
   HttpResponse response;
   MockFileIO mockFileIO;
-
+  int responseCode;
   protected void setUp() {
     mockFileIO = new MockFileIO();
     mockFileIO.setIsFileTrue();
@@ -20,27 +20,31 @@ public class HandlerGetFileContentsTest extends junit.framework.TestCase {
     String path = "/";
     handler = new HandlerGetFileContents(path, mockFileIO);
     response = handler.generateResponse();
-    assertEquals(response.responseCode(), 200);
+    responseCode = (int)response.call()[0];
+    assertEquals(responseCode, 200);
   }
 
   public void testGenerateOkResponseValidFile() {
     String path = "/something.txt";
     handler = new HandlerGetFileContents(path, mockFileIO);
     response = handler.generateResponse();
-    assertEquals(response.responseCode(), 200);
+    responseCode = (int)response.call()[0];
+    assertEquals(responseCode, 200);
   }
 
   public void testGenerateNotFoundResponseforInvalidFile() {
     String path = "/throwIOException";
     handler = new HandlerGetFileContents(path, mockFileIO);
     response = handler.generateResponse();
-    assertEquals(response.responseCode(), 404);
+    responseCode = (int)response.call()[0];
+    assertEquals(responseCode, 404);
   }
 
   public void testContentTypeIsTextHtmlForTxtFile() {
     String path = "/something.txt";
     handler = new HandlerGetFileContents(path, mockFileIO);
     response = handler.generateResponse();
-    assertEquals(response.headers().get("Content-Type"), "text/plain");
+    HashMap<String, String> headers = (HashMap<String, String>)response.call()[1];
+    assertEquals(headers.get("Content-Type"), "text/plain");
   }
 }

--- a/src/test/java/HttpResponseTest.java
+++ b/src/test/java/HttpResponseTest.java
@@ -5,6 +5,8 @@ public class HttpResponseTest extends junit.framework.TestCase {
 
   private HttpResponse response;
   private HashMap<String, String> testMap;
+  int responseCode;
+  HashMap<String, String> headers;
 
   protected void setUp() {
     response = new HttpResponse();
@@ -13,14 +15,18 @@ public class HttpResponseTest extends junit.framework.TestCase {
     testMap.put("key01", "value01");
     testMap.put("key02", "value02");
     response.setBody("12345", "text/plain");
-  }
+    Object[] responseArray = response.call();
+    responseCode = (int)responseArray[0];
+    headers = (HashMap<String, String>)responseArray[1];
+
+}
 
   public void testDefaultResponseLine() {
-    assertEquals(response.responseCode(), 200);
+    assertEquals(responseCode, 200);
   }
 
   public void testGetHeaders() {
-    assertEquals(response.headers().get("testKey"), "testValue");
+    assertEquals(headers.get("testKey"), "testValue");
   }
 
   public void testGetValue() {


### PR DESCRIPTION
Created an `ICallable` interface with a single method `call()` that returns
an `Object[]` which should have the following an `int` `responseCode`, `HashMap<String, String>` `headers`,
and `byte[]` `body`. This is in preparation for the .jar

This is so that someone using the jar only has to implement a single
method, `call()`, for their response object; instead of having to create a
response object that has a `getResponseCode()`, `getHeaders()`, `getBody()`.
