### PR TITLE
Add HttpResponseBuilder class, add call to handler

### DIFF
--- a/src/main/java/handlers/HandlerBadRequest.java
+++ b/src/main/java/handlers/HandlerBadRequest.java
@@ -1,11 +1,16 @@
 package com.td.HttpServer;
 
+import java.util.HashMap;
+
 public class HandlerBadRequest implements IHandler {
 
-  public HttpResponse generateResponse() {
-    HttpResponse rtnResponse = new HttpResponse();
-    rtnResponse.setResponseCode(400);
-    rtnResponse.setBody("Bad Request", ContentType.text);
-    return rtnResponse;
+  public Object[] call() {
+    HashMap<String, String> headers = new HashMap<String, String>();
+    headers.put("Content-Type", ContentType.text);
+    Object[] returnArray = new Object[3];
+    returnArray[0] = 400;
+    returnArray[1] = headers;
+    returnArray[2] = "Bad Request".getBytes();
+    return returnArray;
   }
 }

--- a/src/main/java/handlers/HandlerFileNotFound.java
+++ b/src/main/java/handlers/HandlerFileNotFound.java
@@ -1,11 +1,16 @@
 package com.td.HttpServer;
 
+import java.util.HashMap;
+
 public class HandlerFileNotFound implements IHandler {
 
-  public HttpResponse generateResponse() {
-    HttpResponse rtnResponse = new HttpResponse();
-    rtnResponse.setResponseCode(404);
-    rtnResponse.setBody("File not Found", ContentType.text);
-    return rtnResponse;
+  public Object[] call() {
+    HashMap<String, String> headers = new HashMap<String, String>();
+    headers.put("Content-Type", ContentType.text);
+    Object[] returnArray = new Object[3];
+    returnArray[0] = 404;
+    returnArray[1] = headers;
+    returnArray[2] = "File not Found".getBytes();
+    return returnArray;
   }
 }

--- a/src/main/java/handlers/HandlerGetDirectoryContents.java
+++ b/src/main/java/handlers/HandlerGetDirectoryContents.java
@@ -1,5 +1,5 @@
 package com.td.HttpServer;
-
+import java.util.HashMap;
 import java.io.IOException;
 
 public class HandlerGetDirectoryContents implements IHandler {
@@ -13,18 +13,20 @@ public class HandlerGetDirectoryContents implements IHandler {
     this.dirListHtml = dirListHtml;
   }
 
-  public HttpResponse generateResponse() {
-    HttpResponse rtnResponse = new HttpResponse();
+  public Object[] call() {
+    Object[] returnArray = new Object[3];
+    HashMap<String, String> headers = new HashMap<String, String>();
     try {
       String[] fileList = fileIO.getFiles(path);
-      byte[] body = dirListHtml.buildHtmlPage(path, fileList);
-      rtnResponse.setBody(body, ContentType.html);
+      returnArray[0] = 200;
+      returnArray[2] = dirListHtml.buildHtmlPage(path, fileList);
+      headers.put("Content-Type", ContentType.html);
+    } catch (IOException e) {
+      returnArray[0] = 404;
+      returnArray[2] = "IOExceptoin".getBytes();
+      headers.put("Content-Type", ContentType.text);
     }
-    catch (IOException e) {
-      e.printStackTrace();
-      rtnResponse.setBody("IOException", ContentType.text);
-      rtnResponse.setResponseCode(404);
-    }
-    return rtnResponse;
+    returnArray[1] = headers;
+    return returnArray;
   }
 }

--- a/src/main/java/handlers/HandlerGetFileContents.java
+++ b/src/main/java/handlers/HandlerGetFileContents.java
@@ -1,5 +1,6 @@
 package com.td.HttpServer;
 
+import java.util.HashMap;
 import java.io.IOException;
 
 public class HandlerGetFileContents implements IHandler {
@@ -13,17 +14,21 @@ public class HandlerGetFileContents implements IHandler {
     this.fileIO = fileIO;
   }
 
-  public HttpResponse generateResponse() {
-    HttpResponse rtnResponse = new HttpResponse();
+  public Object[] call() {
+    Object[] returnArray = new Object[3];
+    HashMap<String, String> headers = new HashMap<String, String>();
     try {
-      byte[] body = fileIO.getContent(path);
-      rtnResponse.setBody(body, contentTypeForFileExtension.getContentType(path));
+      returnArray[0] = 200;
+      returnArray[2] = fileIO.getContent(path);
+      headers.put("Content-Type", contentTypeForFileExtension.getContentType(path));
     }
     catch (IOException e) {
       e.printStackTrace();
-      rtnResponse.setBody("IOException", ContentType.text);
-      rtnResponse.setResponseCode(404);
+      returnArray[0] = 404;
+      returnArray[2] = "IOException".getBytes();
+      headers.put("Content-Type", ContentType.text);
     }
-    return rtnResponse;
+    returnArray[1] = headers;
+    return returnArray;
   }
 }

--- a/src/main/java/handlers/HandlerPostFileContents.java
+++ b/src/main/java/handlers/HandlerPostFileContents.java
@@ -1,4 +1,6 @@
 package com.td.HttpServer;
+
+import java.util.HashMap;
 import java.io.IOException;
 
 public class HandlerPostFileContents implements IHandler {
@@ -13,20 +15,24 @@ public class HandlerPostFileContents implements IHandler {
     this.fileIO = fileIO;
   }
 
-  public HttpResponse generateResponse() {
-    HttpResponse rtnResponse = new HttpResponse();
+  public Object[] call() {
+    HashMap<String, String> headers = new HashMap<String, String>();
+    Object[] returnArray = new Object[3];
     try {
       String file = getFileToWrite(path);
       fileIO.writeContent(file, body);
-      rtnResponse.setResponseCode(201);
-      rtnResponse.addHeader("Location", path);
-    }
-    catch (IOException e) {
+      headers.put("Content-Type", ContentType.text);
+      headers.put("Location", path);
+      returnArray[0] = 201;
+      returnArray[2] = new byte[0];
+    } catch (IOException e) {
       e.printStackTrace();
-      rtnResponse.setBody("IOException", ContentType.text);
-      rtnResponse.setResponseCode(404);
+      returnArray[0] = 404;
+      returnArray[2] = "IOException".getBytes();
+      headers.put("Content-Tyep", ContentType.text);
     }
-    return rtnResponse;
+    returnArray[1] = headers;
+    return returnArray;
   }
 
   private String getFileToWrite(String path) throws IOException {

--- a/src/main/java/handlers/HandlerUnprocessableEntity.java
+++ b/src/main/java/handlers/HandlerUnprocessableEntity.java
@@ -1,5 +1,7 @@
 package com.td.HttpServer;
 
+import java.util.HashMap;
+
 public class HandlerUnprocessableEntity implements IHandler {
 
   private String message;
@@ -7,10 +9,14 @@ public class HandlerUnprocessableEntity implements IHandler {
   public HandlerUnprocessableEntity(String message) {
     this.message = message;
   }
-  public HttpResponse generateResponse() {
-    HttpResponse rtnResponse = new HttpResponse();
-    rtnResponse.setResponseCode(422);
-    rtnResponse.setBody(message, ContentType.text);
-    return rtnResponse;
+
+  public Object[] call() {
+    Object[] returnArray = new Object[3];
+    HashMap<String, String> headers = new HashMap<String, String>();
+    headers.put("Content-Type", ContentType.text);
+    returnArray[0] = 422;
+    returnArray[1] = headers;
+    returnArray[2] = message.getBytes();
+    return returnArray;
   }
 }

--- a/src/main/java/httpConnectionProcessing/HttpConnectionToProcess.java
+++ b/src/main/java/httpConnectionProcessing/HttpConnectionToProcess.java
@@ -4,19 +4,22 @@ public class HttpConnectionToProcess {
   IClientSocketIO client;
   IHandlerRouter handlerRouter;
   IRequestBuilder httpRequestBuilder;
+  IResponseBuilder httpResponseBuilder;
   IResponseWriter httpResponseWriter;
 
-  public HttpConnectionToProcess(IClientSocketIO client, IHandlerRouter handlerRouter, IRequestBuilder httpRequestBuilder, IResponseWriter httpResponseWriter) {
+  public HttpConnectionToProcess(IClientSocketIO client, IHandlerRouter handlerRouter, IRequestBuilder httpRequestBuilder, IResponseBuilder httpResponseBuilder, IResponseWriter httpResponseWriter) {
     this.client = client;
     this.handlerRouter = handlerRouter;
     this.httpRequestBuilder = httpRequestBuilder;
+    this.httpResponseBuilder = httpResponseBuilder;
     this.httpResponseWriter = httpResponseWriter;
   }
 
   public void execute() {
     try {
       IHandler handler = getHandler();
-      sendResponse(handler);
+      HttpResponse response = httpResponseBuilder.generateResponse(handler);
+      sendResponse(response);
     }
     catch (BadConnectionException e) {
       e.printStackTrace();
@@ -40,8 +43,7 @@ public class HttpConnectionToProcess {
     return handler;
   }
 
-  private void sendResponse(IHandler handler) throws BadConnectionException {
-    HttpResponse response = handler.generateResponse();
+  private void sendResponse(HttpResponse response) throws BadConnectionException {
     httpResponseWriter.sendHttpResponse(client.clientSocketOutput(), response);
   }
 }

--- a/src/main/java/httpConnectionProcessing/IHandler.java
+++ b/src/main/java/httpConnectionProcessing/IHandler.java
@@ -1,5 +1,5 @@
 package com.td.HttpServer;
 
 public interface IHandler {
-  public HttpResponse generateResponse();
+  public Object[] call();
 }

--- a/src/main/java/httpConnectionProcessing/IResponseBuilder.java
+++ b/src/main/java/httpConnectionProcessing/IResponseBuilder.java
@@ -1,0 +1,5 @@
+package com.td.HttpServer;
+
+public interface IResponseBuilder {
+  public HttpResponse generateResponse(IHandler handler);
+}

--- a/src/main/java/httpResponse/HttpResponse.java
+++ b/src/main/java/httpResponse/HttpResponse.java
@@ -1,18 +1,19 @@
 package com.td.HttpServer;
 
-import java.util.*;
+import java.util.HashMap;
 import java.io.*;
 
 public class HttpResponse {
 
   private int responseCode;
-  private byte[] body;
   private HashMap<String, String> headers;
+  private byte[] body;
 
-  public HttpResponse() {
-    this.responseCode = 200;
-    this.body = "".getBytes();
-    this.headers = new HashMap<String, String>();
+  public HttpResponse(int responseCode, HashMap<String, String> headers, byte[] body) {
+    this.responseCode = responseCode;
+    this.headers = headers;
+    this.body = body;
+    addHeader("Content-Length", contentLength(this.body));
   }
 
   public void setResponseCode(int code) {
@@ -21,16 +22,6 @@ public class HttpResponse {
 
   public int responseCode() {
     return responseCode;
-  }
-
-  public void setBody(byte[] body, String contentType) {
-    this.body = body;
-    addHeader("Content-Length", contentLength(this.body));
-    addHeader("Content-Type", contentType);
-  }
-
-  public void setBody(String body, String contentType) {
-    setBody(body.getBytes(), contentType);
   }
 
   public byte[] body() {

--- a/src/main/java/httpResponse/HttpResponseBuilder.java
+++ b/src/main/java/httpResponse/HttpResponseBuilder.java
@@ -1,0 +1,12 @@
+package com.td.HttpServer;
+
+import java.util.HashMap;
+
+public class HttpResponseBuilder implements IResponseBuilder {
+
+  public HttpResponse generateResponse(IHandler handler) {
+    Object[] responseArray = handler.call();
+
+    return new HttpResponse((int)responseArray[0], (HashMap<String, String>)responseArray[1], (byte[])responseArray[2]);
+  }
+}

--- a/src/main/java/server/HttpServer.java
+++ b/src/main/java/server/HttpServer.java
@@ -19,9 +19,10 @@ public class HttpServer{
     FileIO fileIO = new FileIO(arguments.getDirectory());
     HandlerRouter handlerRouter = new HandlerRouter(fileIO);
     HttpRequestBuilder httpRequestBuilder = new HttpRequestBuilder(httpRequestParser);
+    HttpResponseBuilder httpResponseBuilder = new HttpResponseBuilder();
     HttpResponseWriter httpResponseWriter = new HttpResponseWriter();
     ConnectionProcessRunnerMultiThread connectionProcessRunner = new ConnectionProcessRunnerMultiThread();
-    HttpServerRunner httpServerRunner = new HttpServerRunner(serverSocket, connectionProcessRunner, handlerRouter, httpRequestBuilder, httpResponseWriter);
+    HttpServerRunner httpServerRunner = new HttpServerRunner(serverSocket, connectionProcessRunner, handlerRouter, httpRequestBuilder, httpResponseBuilder, httpResponseWriter);
     System.out.println("HTTP Server running on localhost port " + serverSocket.getLocalPort() +"!");
     System.out.println("Using directory : " + fileIO.workingDirectory());
     httpServerRunner.run();

--- a/src/main/java/server/HttpServerRunner.java
+++ b/src/main/java/server/HttpServerRunner.java
@@ -7,13 +7,15 @@ public class HttpServerRunner {
   private IConnectionProcessRunner httpConnectionProcessRunner;
   private IHandlerRouter handlerRouter;
   private IRequestBuilder httpRequestBuilder;
+  private IResponseBuilder httpResponseBuilder;
   private IResponseWriter httpResponseWriter;
 
-  public HttpServerRunner(ServerSocket serverSocket, IConnectionProcessRunner httpConnectionProcessRunner, IHandlerRouter handlerRouter, IRequestBuilder httpRequestBuilder, IResponseWriter httpResponseWriter) {
+  public HttpServerRunner(ServerSocket serverSocket, IConnectionProcessRunner httpConnectionProcessRunner, IHandlerRouter handlerRouter, IRequestBuilder httpRequestBuilder,IResponseBuilder httpResponseBuilder, IResponseWriter httpResponseWriter) {
     this.serverSocket = serverSocket;
     this.httpConnectionProcessRunner = httpConnectionProcessRunner;
-    this.handlerRouter = handlerRouter; 
+    this.handlerRouter = handlerRouter;
     this.httpRequestBuilder = httpRequestBuilder;
+    this.httpResponseBuilder = httpResponseBuilder;
     this.httpResponseWriter = httpResponseWriter;
   }
 
@@ -27,7 +29,7 @@ public class HttpServerRunner {
         e.printStackTrace();
         continue;
       }
-      HttpConnectionToProcess httpConnectionToProcess = new HttpConnectionToProcess(client, handlerRouter, httpRequestBuilder, httpResponseWriter);
+      HttpConnectionToProcess httpConnectionToProcess = new HttpConnectionToProcess(client, handlerRouter, httpRequestBuilder, httpResponseBuilder, httpResponseWriter);
       httpConnectionProcessRunner.execute(httpConnectionToProcess);
     }
   }

--- a/src/test/java/HandlerGetDirectoryContentsTest.java
+++ b/src/test/java/HandlerGetDirectoryContentsTest.java
@@ -18,32 +18,33 @@ public class HandlerGetDirectoryContentsTest extends junit.framework.TestCase {
     mockFileIO.addToDirectoryContents("file01");
   }
 
+  private HttpResponse getResponse(String path) {
+    handler = new HandlerGetDirectoryContents(path, mockFileIO, dirListHtml);
+    return new HttpResponseBuilder().generateResponse(handler);
+  }
+
   public void testResponseBodyContainsLinks() {
     String path = "/";
-    handler = new HandlerGetDirectoryContents(path, mockFileIO, dirListHtml);
-    response = handler.generateResponse();
+    response = getResponse(path);
     String body = new String(response.body());
     assert(body.contains("<a href=\"/file01\">file01</a>"));
   }
 
   public void testGenerateOkCode() {
     String path = "/";
-    handler = new HandlerGetDirectoryContents(path, mockFileIO, dirListHtml);
-    response = handler.generateResponse();
+    response = getResponse(path);
     assertEquals(200, response.responseCode());
   }
 
   public void testGenerateNotFoundCodeForIOException() {
     String path = "/throwIOException";
-    handler = new HandlerGetDirectoryContents(path, mockFileIO, dirListHtml);
-    response = handler.generateResponse();
+    response = getResponse(path);
     assertEquals(404, response.responseCode());
   }
 
   public void testContentType() {
     String path = "/";
-    handler = new HandlerGetDirectoryContents(path, mockFileIO, dirListHtml);
-    response = handler.generateResponse();
+    response = getResponse(path);
     assertEquals("text/html", response.getValueForHeader("Content-Type"));
   }
 }

--- a/src/test/java/HandlerGetFileContentsTest.java
+++ b/src/test/java/HandlerGetFileContentsTest.java
@@ -16,31 +16,32 @@ public class HandlerGetFileContentsTest extends junit.framework.TestCase {
     mockFileIO.setIsDirectoryFalse();
   }
 
+  private HttpResponse getResponse(String path) {
+    handler = new HandlerGetFileContents(path, mockFileIO);
+    return new HttpResponseBuilder().generateResponse(handler);
+  }
+
   public void testGenerateOkResponseDefaultPath() {
     String path = "/";
-    handler = new HandlerGetFileContents(path, mockFileIO);
-    response = handler.generateResponse();
+    response = getResponse(path);
     assertEquals(response.responseCode(), 200);
   }
 
   public void testGenerateOkResponseValidFile() {
     String path = "/something.txt";
-    handler = new HandlerGetFileContents(path, mockFileIO);
-    response = handler.generateResponse();
+    response = getResponse(path);
     assertEquals(response.responseCode(), 200);
   }
 
   public void testGenerateNotFoundResponseforInvalidFile() {
     String path = "/throwIOException";
-    handler = new HandlerGetFileContents(path, mockFileIO);
-    response = handler.generateResponse();
+    response = getResponse(path);
     assertEquals(response.responseCode(), 404);
   }
 
   public void testContentTypeIsTextHtmlForTxtFile() {
     String path = "/something.txt";
-    handler = new HandlerGetFileContents(path, mockFileIO);
-    response = handler.generateResponse();
+    response = getResponse(path);
     assertEquals(response.headers().get("Content-Type"), "text/plain");
   }
 }

--- a/src/test/java/HandlerPostFileContentsTest.java
+++ b/src/test/java/HandlerPostFileContentsTest.java
@@ -20,25 +20,25 @@ public class HandlerPostFileContentsTest extends junit.framework.TestCase {
   }
 
   public void testHandlerWritesToFileThatDoesNotExsists() {
-    handler.generateResponse();
+    handler.call();
     assert(mockFileIO.exists(path));
   }
 
   public void testHandlerWritesToNewFileIfPathExists() {
     mockFileIO.addToDirectoryContents(path);
-    handler.generateResponse();
+    handler.call();
     assert(mockFileIO.exists(path1));
   }
 
   public void testHandlerWritesToNewFile2IfPathExists() {
     mockFileIO.addToDirectoryContents(path);
     mockFileIO.addToDirectoryContents(path1);
-    handler.generateResponse();
+    handler.call();
     assert(mockFileIO.exists(path2));
   }
 
   public void testLocationHeader() {
-    HttpResponse response = handler.generateResponse();
+    HttpResponse response = new HttpResponseBuilder().generateResponse(handler);
     assertEquals(response.getValueForHeader("Location"), path);
   }
 }

--- a/src/test/java/HttpResponseTest.java
+++ b/src/test/java/HttpResponseTest.java
@@ -7,12 +7,9 @@ public class HttpResponseTest extends junit.framework.TestCase {
   private HashMap<String, String> testMap;
 
   protected void setUp() {
-    response = new HttpResponse();
-    response.addHeader("testKey", "testValue");
     testMap = new HashMap<String, String>();
-    testMap.put("key01", "value01");
-    testMap.put("key02", "value02");
-    response.setBody("12345", "text/plain");
+    testMap.put("Content-Type", "text/plain");
+    response = new HttpResponse(200, testMap, "12345".getBytes());
   }
 
   public void testDefaultResponseLine() {
@@ -20,23 +17,14 @@ public class HttpResponseTest extends junit.framework.TestCase {
   }
 
   public void testGetHeaders() {
-    assertEquals(response.headers().get("testKey"), "testValue");
+    assertEquals(response.headers().get("Content-Type"), "text/plain");
   }
 
   public void testGetValue() {
-    assertEquals(response.getValueForHeader("testKey"), "testValue");
-  }
-
-  public void testAddHashMapToHeaders() {
-    response.addHeaders(testMap);
-    assertEquals(response.getValueForHeader("key02"), "value02");
+    assertEquals(response.getValueForHeader("Content-Type"), "text/plain");
   }
 
   public void testContentLengthGetsSet() {
     assertEquals(response.getValueForHeader("Content-Length"), "5");
-  }
-
-  public void testContentTypeGetsSet() {
-    assertEquals(response.getValueForHeader("Content-Type"), "text/plain");
   }
 }

--- a/src/test/java/HttpResponseWriterTest.java
+++ b/src/test/java/HttpResponseWriterTest.java
@@ -11,11 +11,13 @@ public class HttpResponseWriterTest extends junit.framework.TestCase {
   protected void setUp() {
     mockSocketIO = new MockClientSocketOutput();
     writer = new HttpResponseWriter();
-    response = new HttpResponse();
+    HashMap<String, String> headers = new HashMap<String, String>();
+    headers.put("Content-Type", "text/plain");
+    byte[] body = "This is the response body".getBytes();
+    response = new HttpResponse(200, headers, body);
   }
 
   public void testGeneratedResponseSentOutToSocket() throws BadConnectionException {
-    response.setBody("This is the response body", "text/plain");
     String responseShouldBe = "HTTP/1.1 200 OK\r\nContent-Length: 25\r\nContent-Type: text/plain\r\n\r\nThis is the response body";
     writer.sendHttpResponse(mockSocketIO, response);
     String responseGenerated = new String(mockSocketIO.getReceivedBytes());

--- a/src/test/java/MultiThreadTest.java
+++ b/src/test/java/MultiThreadTest.java
@@ -10,6 +10,7 @@ public class MultiThreadTest extends junit.framework.TestCase {
   HandlerRouter handlerRouter;
   HttpRequestParser httpRequestParser;
   HttpRequestBuilder httpRequestBuilder;
+  HttpResponseBuilder httpResponseBuilder;
   HttpResponseWriter httpResponseWriter;
 
   protected void setUp() {
@@ -17,6 +18,7 @@ public class MultiThreadTest extends junit.framework.TestCase {
     handlerRouter = new HandlerRouter(fileIO);
     httpRequestParser = new HttpRequestParser();
     httpRequestBuilder = new HttpRequestBuilder(httpRequestParser);
+    httpResponseBuilder = new HttpResponseBuilder();
     httpResponseWriter = new HttpResponseWriter();
 
   }
@@ -25,8 +27,8 @@ public class MultiThreadTest extends junit.framework.TestCase {
     MockClientSocket clientLongDelay = new MockClientSocket(1000);
     MockClientSocket clientNoDelay = new MockClientSocket(0);
 
-    HttpConnectionToProcess connectionNoDealy = new HttpConnectionToProcess(clientNoDelay, handlerRouter, httpRequestBuilder, httpResponseWriter);
-    HttpConnectionToProcess connectionLongDelay = new HttpConnectionToProcess(clientLongDelay, handlerRouter, httpRequestBuilder, httpResponseWriter);
+    HttpConnectionToProcess connectionNoDealy = new HttpConnectionToProcess(clientNoDelay, handlerRouter, httpRequestBuilder, httpResponseBuilder, httpResponseWriter);
+    HttpConnectionToProcess connectionLongDelay = new HttpConnectionToProcess(clientLongDelay, handlerRouter, httpRequestBuilder, httpResponseBuilder, httpResponseWriter);
     ConnectionProcessRunnerMultiThread connectionProcessRunnerMutliThread = new ConnectionProcessRunnerMultiThread();
     connectionProcessRunnerMutliThread.execute(connectionLongDelay);
     connectionProcessRunnerMutliThread.execute(connectionNoDealy);


### PR DESCRIPTION
IHanlder now has a call method instead of a generateResposne method.

There is now an HttpResponseBuilder class that has a generateResposne
method which takes an IHanlder and returns a HttpResponse object.

---

The IHandler interface now has a single method call() that returns
an Object[] which should have the following an int responseCode, HashMap<String, String> headers,
and byte[] body. This is in preparation for the .jar

This is so that someone using the jar only has to implement a single
method, call(), for their response object; instead of having to create a
response object that has a getResponseCode(), getHeaders(), getBody().
