### PR TITLE
HttpRequest now has getter for parameters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ jar {
       )
   }
   baseName = 'HttpServer'
-  version = '0.1.4'
+  version = '0.1.5'
 }
 
 sourceCompatibility = 1.8

--- a/src/main/java/httpRequest/HttpRequest.java
+++ b/src/main/java/httpRequest/HttpRequest.java
@@ -4,11 +4,25 @@ import java.util.HashMap;
 public class HttpRequest implements IHttpRequest {
 
   String requestLine;
+  String method;
+  String path;
+  String version;
+  String parameters;
   HashMap<String, String> headers;
   byte[] body;
 
   public HttpRequest(String requestLine, HashMap<String, String> headers) {
     this.requestLine = requestLine;
+    this.method = requestLine.split(" ")[0];
+    String pathAndParameters[] = requestLine.split(" ")[1].split("&");
+    this.path = pathAndParameters[0];
+    if (pathAndParameters.length > 1 ) {
+      this.parameters = pathAndParameters[1];
+    } else {
+      this.parameters = "";
+    }
+
+    this.version = requestLine.split(" ")[2];
     this.headers = headers;
     this.body = new byte[0];
   }
@@ -18,15 +32,19 @@ public class HttpRequest implements IHttpRequest {
   }
 
   public String method() {
-    return requestLine().split(" ")[0];
+    return method;
   }
 
   public String path() {
-    return requestLine().split(" ")[1];
+    return path;
   }
 
   public String version() {
-    return requestLine().split(" ")[2];
+    return version;
+  }
+
+  public String parameters() {
+    return parameters;
   }
 
   public HashMap<String, String> headers() {

--- a/src/main/java/httpRequest/HttpRequest.java
+++ b/src/main/java/httpRequest/HttpRequest.java
@@ -13,6 +13,12 @@ public class HttpRequest implements IHttpRequest {
 
   public HttpRequest(String requestLine, HashMap<String, String> headers) {
     this.requestLine = requestLine;
+    parseRequestLine(requestLine);
+    this.headers = headers;
+    this.body = new byte[0];
+  }
+
+  private void parseRequestLine(String requestLine) {
     this.method = requestLine.split(" ")[0];
     String pathAndParameters[] = requestLine.split(" ")[1].split("&");
     this.path = pathAndParameters[0];
@@ -21,10 +27,7 @@ public class HttpRequest implements IHttpRequest {
     } else {
       this.parameters = "";
     }
-
     this.version = requestLine.split(" ")[2];
-    this.headers = headers;
-    this.body = new byte[0];
   }
 
   public String requestLine() {

--- a/src/test/java/httpRequest/HttpRequestTest.java
+++ b/src/test/java/httpRequest/HttpRequestTest.java
@@ -21,6 +21,20 @@ public class HttpRequestTest extends junit.framework.TestCase {
     assertEquals("/", request.path());
   }
 
+  public void testPathDoesNotIncludeParameters() {
+    request = new HttpRequest("GET /this&parameters HTTP/1.1", headers);
+    assertEquals("/this", request.path());
+  }
+
+  public void testParametersIsEmptyStringIfNoParameters() {
+    assertEquals("", request.parameters());
+  }
+
+  public void testParametersGetSet() {
+    request = new HttpRequest("GET /this&parameters HTTP/1.1", headers);
+    assertEquals("parameters", request.parameters());
+  }
+
   public void testVersionIsHTTP1point1() {
     assertEquals("HTTP/1.1", request.version());
   }


### PR DESCRIPTION
This was done so that parameters could be sent in with a request. Before
this change the parameters were made part of the path and therefore a
request with parameters would not be handled properly by the server.
