### PR TITLE
Added the ability to use wildcard for path

### DIFF
--- a/src/main/java/routing/CustomRoute.java
+++ b/src/main/java/routing/CustomRoute.java
@@ -12,7 +12,19 @@ public class CustomRoute {
   }
 
   public boolean match(String method, String path) {
-    return (this.method.equals(method) && this.path.equals(path));
+    return (methodMatches(method) && pathMatches(path));
+  }
+
+  private boolean methodMatches(String method) {
+    return this.method.equals(method);
+  }
+
+  private boolean pathMatches(String path) {
+    if (this.path.equals("*")) {
+      return true;
+    } else {
+      return this.path.equals(path);
+    }
   }
 
   public IHandler getHandler() {

--- a/src/test/java/routing/CustomRouteTest.java
+++ b/src/test/java/routing/CustomRouteTest.java
@@ -20,4 +20,9 @@ public class CustomRouteTest extends junit.framework.TestCase {
   public void testMatchMethodReturnsFalseForNonMatchPath() {
     assertFalse(testRoute.match("GET", "/that"));
   }
+
+  public void testMatchMethodForWildCardPath() {
+    testRoute = new CustomRoute("GET", "*", new MockHandler());
+    assertTrue(testRoute.match("GET", "/anyPathShouldWork"));
+  }
 }


### PR DESCRIPTION
Custom routes can now use a wildcard for the path. This was done so that
users of the server API have the ability to make a custom route that
overrides a method regardless of the path.

This will be required for passing some of the cobspec tests in the
clojure application. (ie HEAD, OPTIONS, etc)
